### PR TITLE
edit subsetCollection() to fix bug of not subsetting subcollections

### DIFF
--- a/R/accessMSigDB.R
+++ b/R/accessMSigDB.R
@@ -139,8 +139,12 @@ subsetCollection <- function(gsc, collection = c(), subcollection = c()) {
   
   #filter collection & sub-collection
   ctype = lapply(gsc, GSEABase::collectionType)
-  gsc = gsc[sapply(ctype, GSEABase::bcCategory) %in% collection |
-              sapply(ctype, GSEABase::bcSubCategory) %in% subcollection]
+  if (length(subcollection) == 0){
+    gsc = gsc[sapply(ctype, GSEABase::bcCategory) %in% collection]
+  } else {
+    gsc = gsc[sapply(ctype, GSEABase::bcCategory) %in% collection & 
+                sapply(ctype, GSEABase::bcSubCategory) %in% subcollection]
+  }
   
   return(gsc)
 }


### PR DESCRIPTION
The subsetCollection() wasn't able to subset the genesets correctly because of the "|" instead of "&".